### PR TITLE
refactor : 보드 초대시 기존에 이메일 인증된 사람만 초대가 가능하게 기능수정

### DIFF
--- a/src/main/java/com/nbcamp/b4trello/controller/BoardController.java
+++ b/src/main/java/com/nbcamp/b4trello/controller/BoardController.java
@@ -12,9 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -130,7 +128,7 @@ public class BoardController {
         UserBoard userBoard = userBoardRepository.findByUserAndBoard(user, board)
                 .orElseThrow(() -> new RuntimeException(ErrorMessageEnum.BOARD_NOT_FAILEINVIATED.getMessage()));
 
-        String message = boardService.inviteUser(userBoard, boardId, requestDto.getUserEmail());
+        String message = boardService.inviteUser(userDetails, boardId, requestDto.getUserEmail());
 
         CommonResponse<String> response = CommonResponse.<String>builder()
                 .responseEnum(ResponseEnum.INVITE_USER)

--- a/src/main/java/com/nbcamp/b4trello/dto/ErrorMessageEnum.java
+++ b/src/main/java/com/nbcamp/b4trello/dto/ErrorMessageEnum.java
@@ -25,6 +25,7 @@ public enum ErrorMessageEnum {
 	JWT_CLAIMS_EMPTY("토큰 정보가 없습니다."),
 	MAIL_BAD_REQUEST("잘못된 인증번호입니다."),
 	ALREADY_MAIL_ACCESS("이미 인증을 받은 계정입니다."),
+	ALREADY_MAIL_UNACTIVE("이메일 인증이 완료되지 않았습니다"),
 	//board error
 	BOARD_NOT_FOUND("보드를 찾을 수 없습니다."),
 	BOARD_ACCESS_DENIED("보드 접근이 거부되었습니다."),
@@ -33,6 +34,7 @@ public enum ErrorMessageEnum {
 	BOARD_NOT_INVIATION("이미 초대된 사용자 입니다"),
 	BOARD_NOT_INVITED("초대할 권한이 없습니다"),
 	BOARD_NOT_FAILEINVIATED("권한이 없거나,보드가 존재하지 않습니다"),
+	BOARD_ALREADY_INVITED("이미 현재 보드에 초대되었습니다."),
 
 	// Column errors
 	COLUMN_NOT_FOUND("컬럼을 찾을 수 없습니다."),

--- a/src/main/java/com/nbcamp/b4trello/enums/StatusEnum.java
+++ b/src/main/java/com/nbcamp/b4trello/enums/StatusEnum.java
@@ -4,6 +4,7 @@ public enum StatusEnum {
     ACTIVE("Active"),
     VERYFICATION("Verify"),
     DENIED("Denied"),
+
     ROLE_USER("Role User");
 
     private final String userStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #47 

## 📝작업 내용

> 이메일 인증된 유저만 보드 초대를 하고 받을 수 있게 구현했습니다.


## 💬리뷰 요구사항(선택)

> 실제 서비스라 생각하여 기존에 유령회원을 방지하고자 유저쪽에서 이메일 인증을 하는 기능을 구현해주셨고 그에따라 

이메일 인증받은 유저를 대상으로 초대를 하고 받을 수 있게 변경하였습니다.
